### PR TITLE
Insert missing comma

### DIFF
--- a/tool_control.py
+++ b/tool_control.py
@@ -195,7 +195,7 @@ def changeFanSpeed(tool, f_index, status):
 
 def toolEnd(tool, f_index):
     insert_gcodes = [
-        f"RESPOND TYPE=echo MSG=\"Turning off T{tool}\""
+        f"RESPOND TYPE=echo MSG=\"Turning off T{tool}\"",
         f"M104 T{tool} S0",
         f"M106 T{tool} S0",
         f"SET_STEPPER_ENABLE STEPPER=extruder{tool if tool > 0 else ''} ENABLE=0"


### PR DESCRIPTION
This caused malformed G-code, as the two strings get appended without a newline between them.